### PR TITLE
Stricter Heap Huffman

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlib"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.79"
 description = "A smaller re-implementation of Zlib compression and decompression"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To use this in your project, you can add it as a git dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-zlib = { git = "https://github.com/mkpro118/zlib", version = "0.1.0" }
+zlib = { git = "https://github.com/mkpro118/zlib", version = "0.1.1" }
 ```
 
 ## Usage

--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -106,6 +106,8 @@ impl Ord for FreqNode {
         match cmp {
             Ordering::Equal => match (self.1.symbol, other.1.symbol) {
                 (Some(sym_self), Some(sym_other)) => sym_other.cmp(&sym_self),
+                (Some(_), None) => Ordering::Greater,
+                (None, Some(_)) => Ordering::Less,
                 _ => cmp,
             },
             _ => cmp,


### PR DESCRIPTION
Add additional explicit constraints on `FreqNode` to build Huffman Trees with shorter codes.